### PR TITLE
Fix duplicate sitemap integration and add comprehensive efficiency analysis

### DIFF
--- a/EFFICIENCY_REPORT.md
+++ b/EFFICIENCY_REPORT.md
@@ -1,0 +1,74 @@
+# Astro Blog Efficiency Analysis Report
+
+## Overview
+This report documents efficiency improvements identified in the astro-blog codebase during a comprehensive analysis. The findings range from configuration issues to potential bundle size optimizations.
+
+## Issues Identified
+
+### 1. ✅ FIXED: Duplicate Sitemap Integration
+**Impact**: High - Causing unnecessary duplicate processing during builds
+**Location**: `astro.config.mjs` lines 51 and 62
+**Issue**: The `sitemap()` integration was called twice in the integrations array
+**Evidence**: Build output showed "sitemap-index.xml created at dist" twice
+**Fix Applied**: Removed the duplicate `sitemap()` call on line 62
+
+### 2. Unused Dependencies
+**Impact**: Medium - Increasing bundle size and dependency complexity
+**Dependencies Identified**:
+- `tw-to-css` (^0.0.12) - No usage found in main codebase
+- `styled-components` (^6.1.19) - Only used in studio/, not in main site
+
+**Recommendation**: Remove unused dependencies to reduce bundle size and simplify dependency management.
+
+### 3. Large KaTeX Bundle Size
+**Impact**: Medium - Contributing to large build size (23MB total)
+**Issue**: KaTeX fonts are being bundled with many font formats (woff, woff2, ttf)
+**Evidence**: 60+ KaTeX font files in dist/_astro/ directory
+**Recommendation**: 
+- Consider lazy loading KaTeX only on pages that need math rendering
+- Optimize font loading to include only necessary formats
+- Implement font subsetting for KaTeX fonts
+
+### 4. Code Formatting Issues
+**Impact**: Low - Code quality and consistency
+**Files Affected**: Multiple TypeScript and JavaScript files
+**Issues**: Missing semicolons, import organization, trailing commas
+**Evidence**: `bun run check` shows 9 formatting errors
+**Recommendation**: Run `bun run format` to fix formatting issues
+
+### 5. Bundle Size Optimization Opportunities
+**Impact**: Medium - Client-side performance
+**Current State**: 
+- `client.DL-_0xdV.js`: 187.44 kB (59.07 kB gzipped)
+- `ClientRouter.astro_astro_type_script_index_0_lang.DZnDNxNb.js`: 14.84 kB (5.08 kB gzipped)
+
+**Recommendations**:
+- Analyze bundle composition for potential code splitting opportunities
+- Consider lazy loading of non-critical components
+- Review if all imported libraries are necessary
+
+## Build Performance Metrics
+- **Total Build Time**: ~5.7 seconds
+- **Total Build Size**: 23MB
+- **Static Pages Generated**: 5 pages
+- **Client Bundle**: 187KB (59KB gzipped)
+
+## Priority Recommendations
+1. **High Priority**: Remove unused dependencies (`tw-to-css`, `styled-components`)
+2. **Medium Priority**: Optimize KaTeX font loading strategy
+3. **Medium Priority**: Analyze and optimize client bundle size
+4. **Low Priority**: Fix code formatting issues
+
+## Implementation Notes
+The duplicate sitemap integration fix was chosen as the first implementation because:
+- It has immediate impact on build performance
+- It's completely safe with no risk of breaking functionality
+- It addresses a clear configuration error
+- The fix is minimal and easily verifiable
+
+## Testing Verification
+After applying the duplicate sitemap fix:
+- Build completes successfully
+- Only one "sitemap-index.xml created" message appears in build output
+- No new errors introduced
+- All existing functionality preserved

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -59,7 +59,6 @@ export default defineConfig({
         "fa6-brands": ["github", "instagram", "linkedin-in"],
       },
     }),
-    sitemap(),
     opengraphImages({
       render: presets.waveSvg,
       options: {


### PR DESCRIPTION
# Fix duplicate sitemap integration and add comprehensive efficiency analysis

## Summary
This PR removes a duplicate `sitemap()` integration in `astro.config.mjs` that was causing unnecessary processing during builds, and adds a comprehensive efficiency analysis report documenting optimization opportunities across the codebase.

**Key Changes:**
- **Fixed duplicate sitemap integration**: Removed the second `sitemap()` call on line 62 of `astro.config.mjs`
- **Added efficiency analysis**: Created `EFFICIENCY_REPORT.md` documenting 5 categories of efficiency improvements found during codebase analysis

**Build Impact:** Build time improved from ~5.71s to ~5.40s, and build output now shows only one "sitemap-index.xml created" message instead of two.

## Review & Testing Checklist for Human
This is a **🟢 low-risk change** but sitemap functionality is critical for SEO.

- [ ] **Verify sitemap generation works correctly** - Check that `/sitemap-index.xml` is generated and contains all expected pages (home, blog posts, photos, projects)
- [ ] **Confirm build succeeds in your environment** - Run `bun install && bun run build` to ensure no environment-specific issues
- [ ] **Test SEO functionality** - Verify `/robots.txt` still references the sitemap correctly and no SEO metadata is broken

### Notes
- The efficiency report documents additional optimization opportunities but does not implement them - this PR only fixes the duplicate sitemap issue
- The duplicate was confirmed by build output showing "sitemap-index.xml created at dist" twice before the fix
- Other efficiency improvements identified include unused dependencies (`tw-to-css`, `styled-components`) and bundle size optimization opportunities

---
**Link to Devin run:** https://app.devin.ai/sessions/6010cbeaf0104210b1989c2c98cf60a5  
**Requested by:** @refactornator (Liam Lindner)