### PR TITLE
Replace deprecated apple-mobile-web-app-capable meta tag

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -50,5 +50,5 @@ const openGraphImage = image
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 <meta name="theme-color" content="#121212" media="(prefers-color-scheme: dark)" />
-<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -51,4 +51,5 @@ const openGraphImage = image
 <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 <meta name="theme-color" content="#121212" media="(prefers-color-scheme: dark)" />
 <meta name="mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />


### PR DESCRIPTION
## Summary
- Replaces the deprecated `apple-mobile-web-app-capable` meta tag with the standard `mobile-web-app-capable` in `BaseHead.astro`
- Fixes a Chrome console deprecation warning

## Test plan
- [ ] Open site in Chrome and verify the deprecation warning is gone from the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps a single HTML meta tag in the document head to remove a browser deprecation warning, with minimal behavioral impact.
> 
> **Overview**
> Replaces the deprecated `apple-mobile-web-app-capable` meta tag with the standard `mobile-web-app-capable` in `BaseHead.astro` to eliminate Chrome’s deprecation warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8eb9cbcaf73621b9fcbf2834a31054f6ebd44628. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->