### PR TITLE
Remove duplicate sitemap integration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -60,7 +60,6 @@ export default defineConfig({
         "fa6-brands": ["github", "instagram", "linkedin-in"],
       },
     }),
-    sitemap(),
     opengraphImages({
       render: presets.waveSvg,
       options: {


### PR DESCRIPTION
## Summary
- Removed duplicate `sitemap()` call in `astro.config.mjs` that was causing the sitemap to be generated twice during build

The `sitemap()` integration was listed twice (lines 38 and 63), resulting in duplicate "sitemap-index.xml created at dist" messages in the build output. The first instance is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)